### PR TITLE
change channel_targets while breaking bug is unfixed

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -11,7 +11,7 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge patchelf_dev
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -11,7 +11,7 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge patchelf_dev
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -11,7 +11,7 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge patchelf_dev
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -13,7 +13,7 @@ c_stdlib_version:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge patchelf_dev
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -13,7 +13,7 @@ c_stdlib_version:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge patchelf_dev
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/README.md
+++ b/README.md
@@ -86,14 +86,14 @@ Current release info
 Installing patchelf
 ===================
 
-Installing `patchelf` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `patchelf` from the `conda-forge/label/patchelf_dev` channel can be achieved by adding `conda-forge/label/patchelf_dev` to your channels with:
 
 ```
-conda config --add channels conda-forge
+conda config --add channels conda-forge/label/patchelf_dev
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `patchelf` can be installed with `conda`:
+Once the `conda-forge/label/patchelf_dev` channel has been enabled, `patchelf` can be installed with `conda`:
 
 ```
 conda install patchelf
@@ -108,26 +108,26 @@ mamba install patchelf
 It is possible to list all of the versions of `patchelf` available on your platform with `conda`:
 
 ```
-conda search patchelf --channel conda-forge
+conda search patchelf --channel conda-forge/label/patchelf_dev
 ```
 
 or with `mamba`:
 
 ```
-mamba search patchelf --channel conda-forge
+mamba search patchelf --channel conda-forge/label/patchelf_dev
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search patchelf --channel conda-forge
+mamba repoquery search patchelf --channel conda-forge/label/patchelf_dev
 
 # List packages depending on `patchelf`:
-mamba repoquery whoneeds patchelf --channel conda-forge
+mamba repoquery whoneeds patchelf --channel conda-forge/label/patchelf_dev
 
 # List dependencies of `patchelf`:
-mamba repoquery depends patchelf --channel conda-forge
+mamba repoquery depends patchelf --channel conda-forge/label/patchelf_dev
 ```
 
 

--- a/build-locally.py
+++ b/build-locally.py
@@ -106,9 +106,7 @@ def main(args=None):
         action="store_true",
         help="Setup debug environment using `conda debug`",
     )
-    p.add_argument(
-        "--output-id", help="If running debug, specify the output to setup."
-    )
+    p.add_argument("--output-id", help="If running debug, specify the output to setup.")
 
     ns = p.parse_args(args=args)
     verify_config(ns)
@@ -124,9 +122,7 @@ def main(args=None):
         elif ns.config.startswith("win"):
             run_win_build(ns)
     finally:
-        recipe_license_file = os.path.join(
-            "recipe", "recipe-scripts-license.txt"
-        )
+        recipe_license_file = os.path.join("recipe", "recipe-scripts-license.txt")
         if os.path.exists(recipe_license_file):
             os.remove(recipe_license_file)
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "patchelf-feedstock"
-version = "3.47.2"  # conda-smithy version used to generate this file
+version = "3.50.1"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/patchelf-feedstock"
 authors = ["@conda-forge/patchelf"]
 channels = ["conda-forge"]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+# as long as the fix for https://github.com/NixOS/patchelf/issues/492
+# is not part of the release, we cannot push to main without breaking the world
+channel_targets:
+  - conda-forge patchelf_dev


### PR DESCRIPTION
Patchelf 0.18 has a problem (https://github.com/NixOS/patchelf/issues/492) which breaks quite a few things, including conda-build (https://github.com/conda/conda-build/issues/4881). Two years later, we're still waiting for a release with the fix, unfortunately.

The conda-build side of things was guarded against in https://github.com/conda-forge/conda-build-feedstock/pull/243 / https://github.com/conda/conda-build/pull/5607, so the recent merge of #45 which republished 0.18 to the `main` label didn't cause quite as much damage; before that, 0.18 needed to be marked broken c.f. https://github.com/conda-forge/admin-requests/pull/746, https://github.com/conda-forge/admin-requests/pull/854

In this zulip [thread](https://conda-forge.zulipchat.com/#narrow/channel/457337-general/topic/patchelf/with/524647307), the topic came up again, and apparently, some people (e.g. @xhochy & colleagues) rely on 0.18 already. So rather than marking the builds as broken again (https://github.com/conda-forge/admin-requests/pull/1568), I moved them to a `patchelf_dev` label manually. This way people can still opt in where necessary.

This PR intends to close the gap between that modification and the feedstock state, so that we avoid future accidental republication of 0.18 to main.